### PR TITLE
fix: escape escapes in .quote()

### DIFF
--- a/utils/string_utils.test.ts
+++ b/utils/string_utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "../_test.deps.ts";
-import { escapeChar, escapeForWithinString, getStringFromStrOrFunc } from "./string_utils.ts";
+import { escapeForWithinString, getStringFromStrOrFunc } from "./string_utils.ts";
 
 describe("escapeForWithinString", () => {
   function doTest(input: string, expected: string) {
@@ -9,27 +9,21 @@ describe("escapeForWithinString", () => {
   it("should escape the quotes and newline", () => {
     doTest(`"testing\n this out"`, `\\"testing\\\n this out\\"`);
   });
-});
 
-describe("escapeChar", () => {
-  function doTest(input: string, char: string, expected: string) {
-    expect(escapeChar(input, char)).to.equal(expected);
+  function doQuoteTest(input: string, quote: string, expected: string) {
+    expect(escapeForWithinString(input, quote)).to.equal(expected);
   }
 
-  it("should throw when specifying a char length > 1", () => {
-    expect(() => escapeChar("", "ab")).to.throw();
-  });
-
-  it("should throw when specifying a char length < 1", () => {
-    expect(() => escapeChar("", "")).to.throw();
-  });
-
   it("should escape the single quotes when specified", () => {
-    doTest(`'testing "this" out'`, `'`, `\\'testing "this" out\\'`);
+    doQuoteTest(`'testing "this" out'`, `'`, `\\'testing "this" out\\'`);
   });
 
   it("should escape regardless of if the character is already escaped", () => {
-    doTest(`"testing \\"this\\" out"`, `"`, `\\"testing \\\\"this\\\\" out\\"`);
+    doQuoteTest(`"testing \\"this\\" out"`, `"`, `\\"testing \\\\\\"this\\\\\\" out\\"`);
+  });
+
+  it("should escape unicode escape sequences", () => {
+    doQuoteTest(`\\u0009`, `"`, `\\\\u0009`);
   });
 });
 

--- a/utils/string_utils.ts
+++ b/utils/string_utils.ts
@@ -1,19 +1,16 @@
-const newlineRegex = /(\r?\n)/g;
-
 /** @internal */
 export function escapeForWithinString(str: string, quoteKind: string) {
-  return escapeChar(str, quoteKind).replace(newlineRegex, "\\$1");
-}
-
-/** @internal */
-export function escapeChar(str: string, char: string) {
-  if (char.length !== 1) {
-    throw new Error(`Specified char must be one character long.`);
-  }
-
   let result = "";
+  // todo: reduce appends (don't go char by char)
   for (let i = 0; i < str.length; i++) {
-    if (str[i] === char) {
+    if (str[i] === quoteKind) {
+      result += "\\";
+    } else if (str[i] === "\r" && str[i + 1] === "\n") {
+      result += "\\";
+      i++; // skip the \r
+    } else if (str[i] === "\n") {
+      result += "\\";
+    } else if (str[i] === "\\") {
       result += "\\";
     }
     result += str[i];


### PR DESCRIPTION
In quote(), it should escape escapes. So for example, if you provide something like:

```
.quote("\\u0009")
```

It should output:

```
"\\u0009"
```

Rather than:

```
"\u0009"
```

I'm going to do a major release for this bug because a patch might break people.