### PR TITLE
fix: quote() should include newline in literal

### DIFF
--- a/mod.test.ts
+++ b/mod.test.ts
@@ -551,7 +551,7 @@ test`;
     });
 
     it("should write out text surrounded by quotes and escape quotes and new lines", () => {
-      const expected = `"te\\"\\\r\nst"`;
+      const expected = `"te\\"\\r\\n\\\r\nst"`;
       doTest(expected, writer => {
         writer.quote("te\"\r\nst");
       });
@@ -1155,7 +1155,7 @@ describe("#hangingIndent", () => {
     writer.hangingIndent(() => {
       writer.quote("t\nu").newLine().write("t");
     });
-    expect(writer.toString()).to.equal(`"t\\\nu"\n    t`);
+    expect(writer.toString()).to.equal(`"t\\n\\\nu"\n    t`);
   });
 });
 

--- a/utils/string_utils.test.ts
+++ b/utils/string_utils.test.ts
@@ -7,7 +7,7 @@ describe("escapeForWithinString", () => {
   }
 
   it("should escape the quotes and newline", () => {
-    doTest(`"testing\n this out"`, `\\"testing\\\n this out\\"`);
+    doTest(`"testing\n this out"`, `\\"testing\\n\\\n this out\\"`);
   });
 
   function doQuoteTest(input: string, quote: string, expected: string) {

--- a/utils/string_utils.ts
+++ b/utils/string_utils.ts
@@ -6,10 +6,10 @@ export function escapeForWithinString(str: string, quoteKind: string) {
     if (str[i] === quoteKind) {
       result += "\\";
     } else if (str[i] === "\r" && str[i + 1] === "\n") {
-      result += "\\";
+      result += "\\r\\n\\";
       i++; // skip the \r
     } else if (str[i] === "\n") {
-      result += "\\";
+      result += "\\n\\";
     } else if (str[i] === "\\") {
       result += "\\";
     }


### PR DESCRIPTION
The output wasn't including new lines. The following:

```js
export const loaderText = "export async function cacheToLocalDir(url, decompress) {\
    const localPath = await getUrlLocalPath(url);\
    if (localPath == null) {\
        return undefined;\
    }\
```

Should actually be:

```js
export const loaderText = "export async function cacheToLocalDir(url, decompress) {\n\
    const localPath = await getUrlLocalPath(url);\n\
    if (localPath == null) {\n\
        return undefined;\n\
    }\n\
```